### PR TITLE
Allow data predicate mixins

### DIFF
--- a/drf_jsonmask/views.py
+++ b/drf_jsonmask/views.py
@@ -12,7 +12,14 @@ from .utils import collapse_includes_excludes
 class OptimizedQuerySetBase(type):
     def __new__(cls, name, bases, attrs):
         new_cls = super(OptimizedQuerySetBase, cls).__new__(cls, name, bases, attrs)
-        new_cls._data_predicates = new_cls.extract_data_predicates(attrs)
+
+        data_predicates = {}
+        for base in bases:
+            if hasattr(base, '_data_predicates'):
+                data_predicates.update(getattr(base, '_data_predicates'))
+
+        data_predicates.update(new_cls.extract_data_predicates(attrs))
+        new_cls._data_predicates = data_predicates
         return new_cls
 
     def extract_data_predicates(cls, attrs):

--- a/tests/views.py
+++ b/tests/views.py
@@ -13,11 +13,7 @@ from .serializers import (  # CommentSerializer,; UserSerializer,
 )
 
 
-class OptimizedTicketViewSetMixin(OptimizedQuerySetMixin):
-    @data_predicate('author')
-    def load_author(self, queryset):
-        return queryset.prefetch_related('author')
-
+class OptimizedCommentsViewSetMixin(OptimizedQuerySetMixin):
     @data_predicate('comments')
     def load_comments(self, queryset):
         return queryset.prefetch_related('comments')
@@ -27,9 +23,13 @@ class OptimizedTicketViewSetMixin(OptimizedQuerySetMixin):
         return queryset.prefetch_related('comments__author')
 
 
-class TicketViewSet(OptimizedTicketViewSetMixin, viewsets.ReadOnlyModelViewSet):
+class TicketViewSet(OptimizedCommentsViewSetMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Ticket.objects.all()
     serializer_class = TicketSerializer
+
+    @data_predicate('author')
+    def load_author(self, queryset):
+        return queryset.prefetch_related('author')
 
 
 class RawViewSet(rest_views.APIView):

--- a/tests/views.py
+++ b/tests/views.py
@@ -13,10 +13,7 @@ from .serializers import (  # CommentSerializer,; UserSerializer,
 )
 
 
-class TicketViewSet(OptimizedQuerySetMixin, viewsets.ReadOnlyModelViewSet):
-    queryset = Ticket.objects.all()
-    serializer_class = TicketSerializer
-
+class OptimizedTicketViewSetMixin(OptimizedQuerySetMixin):
     @data_predicate('author')
     def load_author(self, queryset):
         return queryset.prefetch_related('author')
@@ -28,6 +25,11 @@ class TicketViewSet(OptimizedQuerySetMixin, viewsets.ReadOnlyModelViewSet):
     @data_predicate('comments.author')
     def load_comment_authors(self, queryset):
         return queryset.prefetch_related('comments__author')
+
+
+class TicketViewSet(OptimizedTicketViewSetMixin, viewsets.ReadOnlyModelViewSet):
+    queryset = Ticket.objects.all()
+    serializer_class = TicketSerializer
 
 
 class RawViewSet(rest_views.APIView):


### PR DESCRIPTION
Allow to inherit data predicates. Also, add Python 3.8 to Travis CI

Scenario:
I have two ViewSets, like `Managers` and `Pawns`, both returning person-like data.

```python
class ManagerViewSet(OptimizedQuerySetMixin...):
    @data_predicate("address")
    def load_address(self, queryset):
        return queryset.select_related("address")

class PawnViewSet(OptimizedQuerySetMixin...):
    @data_predicate("address")
    def load_address(self, queryset):
        return queryset.select_related("address")
```

With this change, it's possible to inherit the data predicates from a base mixin:
```python
class OptimizedPersonViewSetMixin(OptimizedQuerySetMixin):
    @data_predicate("address")
    def load_address(self, queryset):
        return queryset.select_related("address")

class ManagerViewSet(OptimizedPersonViewSetMixin, ...):
    pass

class PawnViewSet(OptimizedPersonViewSetMixin, ...):
    pass
```