### PR TITLE
Add support for django 3.0 (and drop support for Python 2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: false
 language: python
 env:
@@ -9,31 +9,72 @@ matrix:
   fast_finish: true
   include:
   - python: 3.6
-    env: TOXENV=py36-1.11-drf3.5
+    env: TOXENV=py36-1.11-drf3.8
   - python: 3.6
-    env: TOXENV=py36-1.11-drf3.6
+    env: TOXENV=py36-1.11-drf3.9
   - python: 3.6
-    env: TOXENV=py36-2.1-drf3.7
+    env: TOXENV=py36-1.11-drf3.10
+  - python: 3.6
+    env: TOXENV=py36-2.0-drf3.11
+  - python: 3.6
+    env: TOXENV=py36-2.0-drf3.8
+  - python: 3.6
+    env: TOXENV=py36-2.0-drf3.9
+  - python: 3.6
+    env: TOXENV=py36-2.0-drf3.10
+  - python: 3.6
+    env: TOXENV=py36-2.0-drf3.11
   - python: 3.6
     env: TOXENV=py36-2.1-drf3.8
   - python: 3.6
     env: TOXENV=py36-2.1-drf3.9
+  - python: 3.6
+    env: TOXENV=py36-2.1-drf3.10
+  - python: 3.6
+    env: TOXENV=py36-2.1-drf3.11
+  - python: 3.6
+    env: TOXENV=py36-2.2-drf3.10
+  - python: 3.6
+    env: TOXENV=py36-2.2-drf3.11
+  - python: 3.6
+    env: TOXENV=py36-3.0-drf3.11
   - python: 3.7
-    dist: xenial
-    sudo: true
-    env: TOXENV=py37-2.1-drf3.7
+    env: TOXENV=py37-1.11-drf3.8
   - python: 3.7
-    dist: xenial
-    sudo: true
+    env: TOXENV=py37-1.11-drf3.9
+  - python: 3.7
+    env: TOXENV=py37-1.11-drf3.10
+  - python: 3.7
+    env: TOXENV=py37-2.0-drf3.11
+  - python: 3.7
+    env: TOXENV=py37-2.0-drf3.8
+  - python: 3.7
+    env: TOXENV=py37-2.0-drf3.9
+  - python: 3.7
+    env: TOXENV=py37-2.0-drf3.10
+  - python: 3.7
+    env: TOXENV=py37-2.0-drf3.11
+  - python: 3.7
     env: TOXENV=py37-2.1-drf3.8
   - python: 3.7
-    dist: xenial
-    sudo: true
     env: TOXENV=py37-2.1-drf3.9
   - python: 3.7
-    dist: xenial
-    sudo: true
     env: TOXENV=py37-2.1-drf3.10
+  - python: 3.7
+    env: TOXENV=py37-2.1-drf3.11
+  - python: 3.7
+    env: TOXENV=py37-2.2-drf3.10
+  - python: 3.7
+    env: TOXENV=py37-2.2-drf3.11
+  - python: 3.7
+    env: TOXENV=py37-3.0-drf3.11
+  - python: 3.8
+    env: TOXENV=py38-2.2-drf3.10
+  - python: 3.8
+    env: TOXENV=py38-2.2-drf3.11
+  - python: 3.8
+    env: TOXENV=py38-3.0-drf3.11
+
 install:
 - pip install tox coveralls
 script:

--- a/drf_jsonmask/views.py
+++ b/drf_jsonmask/views.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils import six
 from django.utils.functional import cached_property
 from jsonmask import parse_fields, should_include_variable
 from rest_framework import exceptions
@@ -25,8 +24,7 @@ class OptimizedQuerySetBase(type):
         return data_predicates
 
 
-@six.add_metaclass(OptimizedQuerySetBase)
-class OptimizedQuerySetMixin(object):
+class OptimizedQuerySetMixin(object, metaclass=OptimizedQuerySetBase):
     """
     Allows a Google Partial Response query param like to prune results
     """

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
 class BaseModel(models.Model):
@@ -14,7 +13,6 @@ class BaseModel(models.Model):
         abstract = True
 
 
-@python_2_unicode_compatible
 class Ticket(BaseModel):
     title = models.CharField(max_length=255)
     body = models.TextField()
@@ -34,7 +32,6 @@ class Ticket(BaseModel):
         return self.title
 
 
-@python_2_unicode_compatible
 class Comment(BaseModel):
     ticket = models.ForeignKey(Ticket, on_delete=models.deletion.CASCADE, related_name='comments')
     body = models.TextField()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -272,3 +272,15 @@ class TestSettings(DataMixin, TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertNotIn('title', resp.json()[0])
         self.assertNotIn('body', resp.json()[0])
+
+    @override_settings(DRF_JSONMASK_FIELDS_NAME='asdf', DRF_JSONMASK_EXCLUDES_NAME='lkjh')
+    def test_old_field_name_and_excludes_name(self):
+        url = reverse('ticket-list')
+        resp = self.client.get(url + '?asdf=title&lkjh=body')
+        self.assertEqual(resp.status_code, 400)
+
+    @override_settings(DRF_JSONMASK_FIELDS_NAME='asdf', DRF_JSONMASK_EXCLUDES_NAME='lkjh')
+    def test_override_field_name_and_excludes_name(self):
+        url = reverse('ticket-list')
+        resp = self.client.get(url + '?fields=title&excludes=body')
+        self.assertEqual(resp.status_code, 400)

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,24 @@ PYTHONDONTWRITEBYTECODE = true
 envlist =
        flake8,
        isort,
-       py36-{1.11}-drf{3.5,3.6},
-       py36-{2.1}-drf{3.7,3.8,3.9},
-       py37-{2.1}-drf{3.7,3.8,3.9,3.10},
+       py36-{1.11}-drf{3.8,3.9,3.10,3.11},
+       py36-{2.0}-drf{3.8,3.9,3.10,3.11},
+       py36-{2.1}-drf{3.8,3.9,3.10,3.11},
+       py36-{2.2}-drf{3.10,3.11},
+       py36-{3.0}-drf{3.11},
+       py37-{1.11}-drf{3.8,3.9,3.10,3.11},
+       py37-{2.0}-drf{3.8,3.9,3.10,3.11},
+       py37-{2.1}-drf{3.8,3.9,3.10,3.11},
+       py37-{2.2}-drf{3.10,3.11},
+       py37-{3.0}-drf{3.11},
+       py38-{2.2}-drf{3.10,3.11},
+       py38-{3.0}-drf{3.11},
 
 [testenv]
 basepython =
        py36: python3.6
        py37: python3.7
+       py38: python3.8
 usedevelop = true
 commands =
        {envpython} -R -Wonce {envbindir}/coverage run -m django test -v2 --settings=tests.settings {posargs}
@@ -22,11 +32,14 @@ deps =
        factory-boy
        jsonmask
        1.11: Django>=1.11,<2.0
+       2.0: Django>=2.0,<2.1
        2.1: Django>=2.1,<2.2
        2.2: Django>=2.2,<2.3
+       3.0: Django>=3.0,<3.1
        drf3.8: djangorestframework>=3.8,<3.9
        drf3.9: djangorestframework>=3.9,<3.10
        drf3.10: djangorestframework>=3.10,<3.11
+       drf3.11: djangorestframework>=3.11,<3.12
 
 [testenv:flake8]
 usedevelop = false


### PR DESCRIPTION
- Drop support for Python 2.x.
- Add Python 3.8 to the testing matrix
- Add Django 2.0, Django 3.0 to the testing matrix
- Add DRF 3.11 to the testing matrix