### PR TITLE
Fix isort errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Implements Google's Partial Response in Django RestFramework.
 
 ## Requirements
 
-* Python (3.6, 3.7)
-* Django (1.11, 2.0, 2.1)
+* Python (3.6, 3.7, 3.8)
+* Django (1.11, 2.0, 2.1, 2.2, 3.0)
 
 ## Installation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 combine_as_imports=true
 include_trailing_comma=true
 multi_line_output=5
-not_skip=__init__.py
 add_imports =
     from __future__ import unicode_literals
 default_section = THIRDPARTY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ def pytest_configure():
     )
 
     try:
-        import oauth_provider  # NOQA
         import oauth2  # NOQA
+        import oauth_provider  # NOQA
     except ImportError:
         pass
     else:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from __future__ import unicode_literals
 
 import factory

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.conf import settings

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
 from django.contrib.auth import get_user_model
-from drf_jsonmask.serializers import FieldsListSerializerMixin
 from rest_framework import serializers
+
+from drf_jsonmask.serializers import FieldsListSerializerMixin
 
 from .models import Comment, Ticket
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 
+from rest_framework import response, views as rest_views, viewsets
+
 from drf_jsonmask.decorators import data_predicate
 from drf_jsonmask.utils import apply_json_mask_from_request
 from drf_jsonmask.views import OptimizedQuerySetMixin
-from rest_framework import response, views as rest_views, viewsets
 
 from .models import Ticket
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,5 +50,5 @@ deps = flake8
 [testenv:isort]
 usedevelop = false
 basepython = python3
-commands = isort --recursive --check-only --diff drf_jsonmask tests
+commands = isort --check-only --diff drf_jsonmask tests
 deps = isort


### PR DESCRIPTION
With the release of isort 5.x.x, some options were removed, and some new sorting rules were introduced, and this broke the build.

This pull request fix those problems.